### PR TITLE
Support hiera_hash for custom checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ In addition to Monit configuration options, this class accepts other parameters:
 
  * `checks`, useful to pass in Monit checks declared in Hiera.
 
+If your hiera setup supports a hierarchy structure, you can set
+'monit::hiera_merge_strategy' to 'hiera_hash' in order use the hiera_hash function for
+config merging.
+
 Lastly, this class also configures a `system` check with sane defaults. It can
 be disabled or tweaked to fit your needs. This check includes loadavg, cpu,
 memory, swap and filesytem tests.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -80,8 +80,13 @@ class monit::config {
   }
 
   # Additional checks.
-  validate_hash($monit::checks)
-  create_resources('monit::check', $monit::checks)
-
+  if ($monit::hiera_merge_strategy == 'hiera_hash') {
+    $mychecks = hiera_hash('monit::checks', {})
+  }
+  else {
+    $mychecks = $monit::checks
+  }
+  validate_hash($mychecks)
+  create_resources('monit::check', $mychecks)
 }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,6 +60,8 @@ class monit(
   $system_fs_inode_usage   = '80%',
   # Additional checks.
   $checks                  = {},
+  # set to heira_hash in order to merge your hierarchy
+  $hiera_merge_strategy    = undef,
 ) inherits monit::params {
 
   class{'monit::install': } ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,7 +60,7 @@ class monit(
   $system_fs_inode_usage   = '80%',
   # Additional checks.
   $checks                  = {},
-  # set to heira_hash in order to merge your hierarchy
+  # set to hiera_hash in order to merge your hierarchy
   $hiera_merge_strategy    = undef,
 ) inherits monit::params {
 


### PR DESCRIPTION
I added support for hiera_hash for the custom checks so you can merge several hiera levels.
It can be disabled / enabled via a variable and defaults to 'undef' which triggers the original behaviour
