### PR TITLE
Make monit auto-start on Debian Squeeze, as it does not do so by default when installed

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -4,6 +4,16 @@ class monit::service {
     warning("${name} is not part of the public API of the ${module_name} module and should not be directly included in the manifest.")
   }
 
+  #Debian Squeeze's monit package isn't configured to auto-start out of the box
+  if $::operatingsystem == "Debian" and versioncmp($::lsbmajdistrelease, "6") == 0 {
+    augeas { "monit_defaults":
+      context => "/files/etc/default/monit",
+      onlyif  => "get /files/etc/default/monit/startup != '1'",
+      changes => "set /files/etc/default/monit/startup 1",
+      notify  => Service[$monit::service],
+    }
+  }
+
   service { $monit::service:
     ensure => $monit::service_ensure,
     enable => $monit::service_enable,


### PR DESCRIPTION
Attempts to fix #14