### PR TITLE
Allow monit to be installed without mmonit requirement

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,7 +27,7 @@ class monit(
   $eventqueue              = $monit::params::eventqueue,
   $eventqueue_basedir      = '/var/monit',
   $eventqueue_slots        = 100,
-  $mmonit_url              = undef,
+  $mmonit_url              = '',
   $mailserver              = undef,
   $mailformat_from         = "monit@${::fqdn}",
   # NOTE: reply-to available since monit 5.2

--- a/templates/conf_file_overrides.erb
+++ b/templates/conf_file_overrides.erb
@@ -12,7 +12,7 @@ set eventqueue
     basedir <%= scope['monit::eventqueue_basedir'] %>
     slots <%= scope['monit::eventqueue_slots'] %>
 <% end -%>
-<% if scope['monit::mmonit_url'] %>
+<% if !scope.lookupvar('monit::mmonit_url').empty? %>
 set mmonit <%= scope['monit::mmonit_url'] %>
 <% end -%>
 


### PR DESCRIPTION
This works for me on CentOS
