### PR TITLE
missing space for tests before UNIXSOCKET

### DIFF
--- a/lib/puppet/parser/functions/monit_validate_tests.rb
+++ b/lib/puppet/parser/functions/monit_validate_tests.rb
@@ -125,7 +125,7 @@ module Puppet::Parser::Functions
         end
         condition = 'FAILED'
         if test.key? 'unixsocket'
-          condition += "UNIXSOCKET #{test['unixsocket']}"
+          condition += " UNIXSOCKET #{test['unixsocket']}"
         else
           if test.key? 'host'
             condition += " HOST #{test['host']} PORT #{test['port']}"


### PR DESCRIPTION
Spaces was missing in service tests validation function, which produced invalid configs if unixsocket test was used:

FAILEDUNIXSOCKET instead of FAILED UNIXSOCKET