### PR TITLE
Update instance.pp

### DIFF
--- a/manifests/check/instance.pp
+++ b/manifests/check/instance.pp
@@ -33,7 +33,6 @@ define monit::check::instance(
   $tests_real = monit_validate_tests($type, $tests)
   $content = template('monit/check/common.erb')
   concat::fragment { "${file}_${name}":
-    ensure  => $ensure,
     target  => $file,
     content => "${header}${content}",
     order   => $order,


### PR DESCRIPTION
puppetlabs-concat v2.1.0 reports:

The $ensure parameter to concat::fragment is deprecated and has no effect.