### PR TITLE
Make bind IP address optional.

### DIFF
--- a/doc/puppet_classes/monit.html
+++ b/doc/puppet_classes/monit.html
@@ -1018,7 +1018,7 @@ class monit(
   Array[String] $alerts                    = [],
   Boolean $httpserver                      = true,
   Integer[1024, 65535] $httpserver_port    = 2812,
-  String $httpserver_bind_address          = &#39;localhost&#39;,
+  String $httpserver_bind_address          = undef,
   Boolean $httpserver_ssl                  = false,
   Optional[
     Stdlib::Absolutepath

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,7 +90,7 @@ class monit(
   Array[String] $alerts                    = [],
   Boolean $httpserver                      = true,
   Integer[1024, 65535] $httpserver_port    = 2812,
-  String $httpserver_bind_address          = 'localhost',
+  String $httpserver_bind_address          = undef,
   Boolean $httpserver_ssl                  = false,
   Optional[
     Stdlib::Absolutepath


### PR DESCRIPTION
The use address parameter is optional in monti configs, and setting it to localhost as is done by the module is too restrictive. This patch relaxes this limitation.

Signed-off-by: Wojciech Dec <wdec@cisco.com>