### PR TITLE
Allow up-to-date versions of the stdlib and concat modules to be used

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.14.0 < 7.0.0"
+      "version_requirement": ">= 4.14.0 < 9.0.0"
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.2.1 < 7.0.0"
+      "version_requirement": ">= 1.2.1 < 8.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Otherwise, this prevents installation of this module here together with other modules that require current versions.