### PR TITLE
Support `https` as test protocol

### DIFF
--- a/lib/puppet/functions/monit_validate_tests.rb
+++ b/lib/puppet/functions/monit_validate_tests.rb
@@ -30,6 +30,7 @@ Puppet::Functions.create_function('monit_validate_tests') do
     # CHANGES: Param 'HOSTHEADER' changed to 'HTTP HEADERS' in monit 5.9, see https://mmonit.com/monit/changes/
     'GENERIC'       => ['SEND', 'EXPECT'],
     'HTTP'          => ['REQUEST', 'STATUS', 'CHECKSUM', 'HOSTHEADER', 'HTTP HEADERS', 'CONTENT'],
+    'HTTPS'          => ['REQUEST', 'STATUS', 'CHECKSUM', 'HOSTHEADER', 'HTTP HEADERS', 'CONTENT'],
     'APACHE-STATUS' => ['LOGLIMIT', 'CLOSELIMIT', 'DNSLIMIT', 'KEEPALIVELIMIT', 'REPLYLIMIT', 'REQUESTLIMIT', 'STARTLIMIT', 'WAITLIMIT', 'GRACEFULLIMIT', 'CLEANUPLIMIT'],
   }.freeze
 

--- a/lib/puppet/functions/monit_validate_tests.rb
+++ b/lib/puppet/functions/monit_validate_tests.rb
@@ -154,7 +154,7 @@ Puppet::Functions.create_function('monit_validate_tests') do
               # fallback to generic test.
               pt_type = PROTOCOL_TESTS.key?(test['protocol']) ? test['protocol'] : 'GENERIC'
               case pt_type
-              when 'HTTP', 'APACHE-STATUS'
+              when 'HTTP', 'HTTPS', 'APACHE-STATUS'
                 pt_options = PROTOCOL_TESTS[pt_type]
                 # Validate test options.
                 raise Puppet::ParseError, exception_prefix + "protocol_test must be a hash with any of this keys: #{pt_options.join(', ')}." unless test['protocol_test'].class == Hash


### PR DESCRIPTION
`https` seems to be a protocol built into Monit, although I cannot find an authoritative list of available protocols to cite here.