### PR TITLE
Update template to fix #70

### DIFF
--- a/templates/check/common.erb
+++ b/templates/check/common.erb
@@ -5,7 +5,7 @@
 <%- unless @depends.empty? -%>
   DEPENDS <%= @depends.join(', ') %>
 <%- end -%>
-<%- unless @every.nil? -%>
+<%- unless @every.nil? or @every.empty? -%>
   EVERY <%= @every %>
 <%- end -%>
 <%- unless @alerts.empty? -%>


### PR DESCRIPTION
This is a follow-up fix for #69 to correctly deal with `every` parameters that may be `undef`.
